### PR TITLE
Adding ability to prevent reverse geocoding

### DIFF
--- a/Our.Umbraco.GoogleMaps/Controls/GoogleMap.css
+++ b/Our.Umbraco.GoogleMaps/Controls/GoogleMap.css
@@ -29,3 +29,18 @@
 	height: 375px;
 	width: 461px;
 }
+
+/* Fixing scrollbars in fmText*/
+.fmText {
+    min-width: 200px;
+    max-width: 200px;
+}
+
+    .fmText > div {
+        overflow: hidden;
+        white-space: nowrap;
+    }
+
+        .fmText > div > div {
+            white-space: normal;
+        }

--- a/Our.Umbraco.GoogleMaps/DataTypes/SingleLocation/SingleLocation.js
+++ b/Our.Umbraco.GoogleMaps/DataTypes/SingleLocation/SingleLocation.js
@@ -2,357 +2,373 @@ if (UmbracoGoogleMap == undefined) var UmbracoGoogleMap = {};
 if (!UmbracoGoogleMap.defaultLocation) { UmbracoGoogleMap.defaultLocation = ''; }
 if (!UmbracoGoogleMap.searchFilter) { UmbracoGoogleMap.searchFilter = ''; }
 if (!UmbracoGoogleMap.useOnlyOnePoint) { UmbracoGoogleMap.useOnlyOnePoint = false; }
+if (!UmbracoGoogleMap.reverseGeocode) { UmbracoGoogleMap.reverseGeocode = true; }
 
 var UmbracoGoogleMapMapDataType = null;
 
 UmbracoGoogleMap.mapDatatype = function () {
-	this._maps = new Object();
-	this._apiLoaded = false;
-	this._editControlId = 0;
-	this._id = 0;
-	this._container = null;
-	this._renderedTabs = new Object();
+    this._maps = new Object();
+    this._apiLoaded = false;
+    this._editControlId = 0;
+    this._id = 0;
+    this._container = null;
+    this._renderedTabs = new Object();
 };
 
 UmbracoGoogleMap.map = function (id, container) {
-	this._id = id;
-	this._container = container;
-	this._map = null;
-	this._markers = new Array();
-	this._val = '';
+    this._id = id;
+    this._container = container;
+    this._map = null;
+    this._markers = new Array();
+    this._val = '';
 };
 
 UmbracoGoogleMap.map.prototype = {
-	draw: function (data) {
+    draw: function (data) {
 
-		var self = this;
+        var self = this;
 
-		var coords = new google.maps.LatLng(0, 0);
-		var zoom = 13;
-		var options = {
-			zoom: zoom,
-			center: coords,
-			mapTypeId: google.maps.MapTypeId.ROADMAP
-		}
+        var coords = new google.maps.LatLng(0, 0);
+        var zoom = 13;
+        var options = {
+            zoom: zoom,
+            center: coords,
+            mapTypeId: google.maps.MapTypeId.ROADMAP
+        }
 
-		this._markers = new Array();
-		this._map = new google.maps.Map(document.getElementById(this._id), options);
+        this._markers = new Array();
+        this._map = new google.maps.Map(document.getElementById(this._id), options);
 
-		var markers = this._markers;
-		var context = this;
+        var markers = this._markers;
+        var context = this;
 
-		var infowindow = new google.maps.InfoWindow({
-			content: 'Loading...'
-		});
+        var infowindow = new google.maps.InfoWindow({
+            content: 'Loading...'
+        });
 
-		var limit = UmbracoGoogleMap.useOnlyOnePoint ? 1 : data.length;
+        var limit = UmbracoGoogleMap.useOnlyOnePoint ? 1 : data.length;
 
-		for (var i = 0; i < limit; i++) {
+        for (var i = 0; i < limit; i++) {
 
-			var result = data[i];
+            var result = data[i];
 
-			var name = result.formatted_address;
-			name = name.replace(/'/, "\\'");
+            var name = result.formatted_address;
+            name = name.replace(/'/, "\\'");
 
-			var marker = new google.maps.Marker({
-				map: this._map,
-				position: result.geometry.location,
-				draggable: true,
-				html: '<span class="fmText">' + name + '<br/><a href="#" onClick="UmbracoGoogleMapMapDataType.markerClick(\'' + context._id + '\', ' + context._markers.length + '); return false;">Use this location</a></span>'
-			});
+            var marker = new google.maps.Marker({
+                map: this._map,
+                position: result.geometry.location,
+                draggable: true,
+                html: '<div class="fmText"><div><div>' + name + '<br/><a href="#" onClick="UmbracoGoogleMapMapDataType.markerClick(\'' + context._id + '\', ' + context._markers.length + '); return false;">Use this location</a></div></div></div>'
+            });
 
-			if (UmbracoGoogleMap.useOnlyOnePoint) {
+            if (UmbracoGoogleMap.useOnlyOnePoint) {
 
-				google.maps.event.addListener(marker, 'dragend', function (e) {
-					UmbracoGoogleMapMapDataType.setMarker(self, marker);
-				});
+                google.maps.event.addListener(marker, 'dragend', function (e) {
+                    UmbracoGoogleMapMapDataType.setMarker(self, marker);
+                });
 
-				UmbracoGoogleMapMapDataType.setMarker(self, marker, zoom);
+                UmbracoGoogleMapMapDataType.setMarker(self, marker, zoom);
 
-			} else {
+            } else {
 
-				google.maps.event.addListener(marker, 'click', function () {
-					infowindow.setContent(this.html);
-					infowindow.open(context._map, this);
-				});
+                google.maps.event.addListener(marker, 'click', function () {
+                    infowindow.setContent(this.html);
+                    infowindow.open(context._map, this);
+                });
 
-				google.maps.event.addListener(marker, 'drag', function () {
-					infowindow.close();
-				});
+                google.maps.event.addListener(marker, 'drag', function () {
+                    infowindow.close();
+                });
 
-				google.maps.event.addListener(marker, 'dragend', function (e) {
-					//this.title = e.latLng.lat() + ', ' + e.latLng.lng();
-					//infowindow.content = '<span class="fmText">' + this.title + '<br/><a href="#" onClick="UmbracoGoogleMapMapDataType.markerClick(\'' + context._id + '\', 0); return false;">Use this location</a></span>'
-				});
-			}
+                google.maps.event.addListener(marker, 'dragend', function (e) {
+                    //this.title = e.latLng.lat() + ', ' + e.latLng.lng();
+                    //infowindow.content = '<span class="fmText">' + this.title + '<br/><a href="#" onClick="UmbracoGoogleMapMapDataType.markerClick(\'' + context._id + '\', 0); return false;">Use this location</a></span>'
+                });
+            }
 
-			context._markers[context._markers.length] = marker;
-		}
+            context._markers[context._markers.length] = marker;
+        }
 
-		//  Create a new viewpoint bound
-		var bounds = new google.maps.LatLngBounds();
+        //  Create a new viewpoint bound
+        var bounds = new google.maps.LatLngBounds();
 
-		//  Go through each...
-		$.each(this._markers, function (index, marker) {
-			bounds.extend(marker.position);
-		});
+        //  Go through each...
+        $.each(this._markers, function (index, marker) {
+            bounds.extend(marker.position);
+        });
 
-		//  Fit these bounds to the map
-		this._map.fitBounds(bounds);
+        //  Fit these bounds to the map
+        this._map.fitBounds(bounds);
 
-		if (this._map.getZoom() > zoom) {
-			this._map.setZoom(zoom);
-		}
-	},
+        if (this._map.getZoom() > zoom) {
+            this._map.setZoom(zoom);
+        }
+    },
 
-	render: function () {
-		var self = this;
-		var v = jQuery('input.value', this._container).attr('value')
-		var mapId = jQuery('div.map', this._container).attr('id');
-		UmbracoGoogleMap.defaultLocation = jQuery('input.defaultloc', this._container).attr('value');
-		UmbracoGoogleMap.searchFilter = jQuery('input.searchFilter', this._container).attr('value');
-		UmbracoGoogleMap.useOnlyOnePoint = jQuery('input.useOnlyOnePoint', this._container).attr('value') == 'true' ? true : false;
+    render: function () {
+        var self = this;
+        var v = jQuery('input.value', this._container).attr('value')
+        var mapId = jQuery('div.map', this._container).attr('id');
+        UmbracoGoogleMap.defaultLocation = jQuery('input.defaultloc', this._container).attr('value');
+        UmbracoGoogleMap.searchFilter = jQuery('input.searchFilter', this._container).attr('value');
+        UmbracoGoogleMap.useOnlyOnePoint = jQuery('input.useOnlyOnePoint', this._container).attr('value') == 'true' ? true : false;
+        UmbracoGoogleMap.reverseGeocode = jQuery('input.reverseGeocode', this._container).attr('value') == 'true' ? true : false;
 
-		var coords = new google.maps.LatLng(0, 0);
-		var zoom = 13;
-		var lat = 37.4419;
-		var lon = -122.1419;
+        var coords = new google.maps.LatLng(0, 0);
+        var zoom = 13;
+        var lat = 37.4419;
+        var lon = -122.1419;
 
-		this._map = new google.maps.Map(document.getElementById(this._id));
+        this._map = new google.maps.Map(document.getElementById(this._id));
 
-		if (v.length == 0) {
+        if (v.length == 0) {
 
-			if (UmbracoGoogleMap.defaultLocation.match(/^\-*[\d\.]+,\-*[\d\.]+,\d+/)) {
-				var loc = UmbracoGoogleMap.defaultLocation.split(',');
-				lat = parseFloat(loc[0]);
-				lon = parseFloat(loc[1]);
-				zoom = parseInt(loc[2]);
-			} else if (UmbracoGoogleMap.defaultLocation.match(/^\-*[\d\.]+,\-*[\d\.]+$/)) {
-				var loc = UmbracoGoogleMap.defaultLocation.split(',');
-				lat = parseFloat(loc[0]);
-				lon = parseFloat(loc[1]);
-			}
+            if (UmbracoGoogleMap.defaultLocation.match(/^\-*[\d\.]+,\-*[\d\.]+,\d+/)) {
+                var loc = UmbracoGoogleMap.defaultLocation.split(',');
+                lat = parseFloat(loc[0]);
+                lon = parseFloat(loc[1]);
+                zoom = parseInt(loc[2]);
+            } else if (UmbracoGoogleMap.defaultLocation.match(/^\-*[\d\.]+,\-*[\d\.]+$/)) {
+                var loc = UmbracoGoogleMap.defaultLocation.split(',');
+                lat = parseFloat(loc[0]);
+                lon = parseFloat(loc[1]);
+            }
 
-			coords = new google.maps.LatLng(lat, lon);
-			
-		} else {
+            coords = new google.maps.LatLng(lat, lon);
 
-			var pointData = v.split(',');
+        } else {
 
-			lat = parseFloat(pointData[0]);
-			lon = parseFloat(pointData[1]);
-			zoom = parseInt(pointData[2]);
+            var pointData = v.split(',');
 
-			coords = new google.maps.LatLng(lat, lon);
+            lat = parseFloat(pointData[0]);
+            lon = parseFloat(pointData[1]);
+            zoom = parseInt(pointData[2]);
 
-			if (!UmbracoGoogleMap.useOnlyOnePoint) {
-				var marker = new google.maps.Marker({
-					map: this._map,
-					position: coords,
-					draggable: true,
-					html: '<span class="fmText">' + lat + ', ' + lon + '<br/><a href="#" onClick="UmbracoGoogleMapMapDataType.markerClick(\'' + this._id + '\', 0); return false;">Use this location</a></span>'
-				});
+            coords = new google.maps.LatLng(lat, lon);
 
-				var infowindow = new google.maps.InfoWindow({
-					content: 'Loading...'
-				});
+            if (!UmbracoGoogleMap.useOnlyOnePoint) {
+                var marker = new google.maps.Marker({
+                    map: this._map,
+                    position: coords,
+                    draggable: true,
+                    html: '<span class="fmText">' + lat + ', ' + lon + '<br/><a href="#" onClick="UmbracoGoogleMapMapDataType.markerClick(\'' + this._id + '\', 0); return false;">Use this location</a></span>'
+                });
 
-				this._markers[0] = marker;
+                var infowindow = new google.maps.InfoWindow({
+                    content: 'Loading...'
+                });
 
-				var map2 = this._map;
-				google.maps.event.addListener(marker, 'click', function () {
-					infowindow.setContent(this.html);
-					infowindow.open(map2, this);
-				});
+                this._markers[0] = marker;
 
-				google.maps.event.addListener(marker, 'drag', function () {
-					infowindow.close();
-				});
+                var map2 = this._map;
+                google.maps.event.addListener(marker, 'click', function () {
+                    infowindow.setContent(this.html);
+                    infowindow.open(map2, this);
+                });
 
-				google.maps.event.addListener(marker, 'dragend', function (e) {
-					//marker.title = e.latLng.lat() + ', ' + e.latLng.lng();
-					//infowindow.content = '<span class="fmText">' + marker.title + '<br/><a href="#" onClick="UmbracoGoogleMapMapDataType.markerClick(\'' + this._id + '\', 0); return false;">Use this location</a></span>'
-				});
-			}
-		}
+                google.maps.event.addListener(marker, 'drag', function () {
+                    infowindow.close();
+                });
 
-		if (UmbracoGoogleMap.useOnlyOnePoint) {
-			var marker = new google.maps.Marker({
-				map: this._map,
-				position: coords,
-				draggable: true,
-			});
+                google.maps.event.addListener(marker, 'dragend', function (e) {
+                    //marker.title = e.latLng.lat() + ', ' + e.latLng.lng();
+                    //infowindow.content = '<span class="fmText">' + marker.title + '<br/><a href="#" onClick="UmbracoGoogleMapMapDataType.markerClick(\'' + this._id + '\', 0); return false;">Use this location</a></span>'
+                });
+            }
+        }
 
-			google.maps.event.addListener(marker, 'dragend', function (e) {
-				UmbracoGoogleMapMapDataType.setMarker(self, marker);
-			});
+        if (UmbracoGoogleMap.useOnlyOnePoint) {
+            var marker = new google.maps.Marker({
+                map: this._map,
+                position: coords,
+                draggable: true,
+            });
 
-			google.maps.event.addListener(this._map, 'zoom_changed', function (e) {
-			    UmbracoGoogleMapMapDataType.setMarker(self, marker);
-			});
+            google.maps.event.addListener(marker, 'dragend', function (e) {
+                UmbracoGoogleMapMapDataType.setMarker(self, marker);
+            });
 
-			this._markers[0] = marker;
-			UmbracoGoogleMapMapDataType.setMarker(self, marker, zoom);
-		}
+            google.maps.event.addListener(this._map, 'zoom_changed', function (e) {
+                UmbracoGoogleMapMapDataType.setMarker(self, marker);
+            });
 
-		var options = {
-			zoom: zoom,
-			center: coords,
-			mapTypeId: google.maps.MapTypeId.ROADMAP
-		}
+            this._markers[0] = marker;
+            UmbracoGoogleMapMapDataType.setMarker(self, marker, zoom);
+        }
 
-		this._map.setOptions(options);
-	}
+        var options = {
+            zoom: zoom,
+            center: coords,
+            mapTypeId: google.maps.MapTypeId.ROADMAP
+        }
+
+        this._map.setOptions(options);
+    }
 }
 
 UmbracoGoogleMap.mapDatatype.prototype = {
-	setMarker: function (map, marker, zoom) {
-	    var z = zoom ? zoom : map._map.getZoom();
-		var l = marker.getPosition();
-		var lat = l.lat();
-		var lon = l.lng();
-		var val = lat + ',' + lon + (z ? ',' + z : '');
+    setMarker: function (map, marker, zoom) {
+        var z = zoom ? zoom : map._map.getZoom();
+        var l = marker.getPosition();
+        var lat = l.lat();
+        var lon = l.lng();
+        var val = lat + ',' + lon + (z ? ',' + z : '');
 
-		jQuery("input.value", map._container).attr('value', val);
-		map._val = val;
-	},
+        jQuery("input.value", map._container).attr('value', val);
+        map._val = val;
+    },
 
-	markerClick: function (mapId, markerId) {
-		var map = this._maps[mapId];
-		var marker = map._markers[markerId];
+    markerClick: function (mapId, markerId) {
+        var map = this._maps[mapId];
+        var marker = map._markers[markerId];
 
-		this.setMarker(map, marker);
-	},
+        this.setMarker(map, marker);
+    },
 
-	edit: function () {
-		this._apiLoaded = true;
-		this._maps[this._id] = new UmbracoGoogleMap.map(this._id, this._container);
+    edit: function () {
+        this._apiLoaded = true;
+        this._maps[this._id] = new UmbracoGoogleMap.map(this._id, this._container);
 
-		this._maps[this._id].render();
-	},
+        this._maps[this._id].render();
+    },
 
-	preEdit: function (id, container) {
+    preEdit: function (id, container) {
 
-		this._id = id;
-		this._container = container;
+        this._id = id;
+        this._container = container;
 
-		if (this._apiLoaded) {
-			this.edit();
-		} else {
-			UmbracoGoogleMap.loadMapsApi('UmbracoGoogleMapMapDataType.edit');
-		}
+        if (this._apiLoaded) {
+            this.edit();
+        } else {
+            UmbracoGoogleMap.loadMapsApi('UmbracoGoogleMapMapDataType.edit');
+        }
 
-	},
+    },
 
-	guiMap: function () {
-		var context = this;
-		this._apiLoaded = true;
-		jQuery('div.gmapContainer').each(function () {
-			var id = jQuery('div.map', this).attr('id');
-			context._maps[id] = new UmbracoGoogleMap.map(id, this);
-			context._maps[id].render();
-		});
-	},
+    guiMap: function () {
+        var context = this;
+        this._apiLoaded = true;
+        jQuery('div.gmapContainer').each(function () {
+            var id = jQuery('div.map', this).attr('id');
+            context._maps[id] = new UmbracoGoogleMap.map(id, this);
+            context._maps[id].render();
+        });
+    },
 
-	clear: function (button) {
-	    var container = button.parentNode.parentNode;
-		jQuery('input.value', container).val('');
+    clear: function (button) {
+        var container = button.parentNode.parentNode;
+        jQuery('input.value', container).val('');
 
-		if (UmbracoGoogleMap.useOnlyOnePoint) {
-		    var id = container.id;
-		    var mapId = jQuery('div.map', container).attr('id');
-		    var map = this._maps[mapId];
-		    map.render();
-		}
-	},
+        if (UmbracoGoogleMap.useOnlyOnePoint) {
+            var id = container.id;
+            var mapId = jQuery('div.map', container).attr('id');
+            var map = this._maps[mapId];
+            map.render();
+        }
+    },
 
-	search: function (button) {
-		var container = button.parentNode.parentNode;
-		var id = container.id;
-		var searchTerm = jQuery('input.place', container).val() + ' ' + UmbracoGoogleMap.searchFilter;
-		var mapId = jQuery('div.map', container).attr('id');
-		var map = this._maps[mapId];
+    search: function (button) {
+        var container = button.parentNode.parentNode;
+        var id = container.id;
+        var searchTerm = jQuery('input.place', container).val() + ' ' + UmbracoGoogleMap.searchFilter;
+        var mapId = jQuery('div.map', container).attr('id');
+        var map = this._maps[mapId];
 
-		var geocoder = new google.maps.Geocoder();
-		geocoder.geocode({ 'address': searchTerm }, function (data, status) {
-			if (status == google.maps.GeocoderStatus.OK) {
-				map.draw(data);
-			} else {
-				alert('Your search didn\'t return any results');
-			}
-		});
-	}
+        // Just draw the given points if a gelocation is passed and reverse geocoding is disabled.
+        if (/[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),\s*[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)|"/.test(jQuery.trim(searchTerm)) && !UmbracoGoogleMap.reverseGeocode) {
+            var latlng = searchTerm.split(","),
+		        fauxData = [
+		    {
+		        formatted_address: "",
+		        geometry: {
+		            location: new google.maps.LatLng(latlng[0], latlng[1])
+		        }
+		    }];
+            map.draw(fauxData);
+            return;
+        }
+
+        var geocoder = new google.maps.Geocoder();
+        geocoder.geocode({ 'address': searchTerm }, function (data, status) {
+            if (status == google.maps.GeocoderStatus.OK) {
+                map.draw(data);
+            } else {
+                alert('Your search didn\'t return any results');
+            }
+        });
+    }
 };
 
 UmbracoGoogleMap.loadMapsApi = function (cb) {
-	jQuery.ajax({
-		type: "get",
-		dataType: "script",
-		url: '//maps.google.com/maps/api/js',
-		data: {
-			v: "3.8",
-			sensor: false,
-			callback: cb
-		},
-		error: function () { alert('Could not load Google Maps API'); }
-	});
+    jQuery.ajax({
+        type: "get",
+        dataType: "script",
+        url: '//maps.google.com/maps/api/js',
+        data: {
+            v: "3.8",
+            sensor: false,
+            callback: cb
+        },
+        error: function () { alert('Could not load Google Maps API'); }
+    });
 }
 
 UmbracoGoogleMapMapDataType = new UmbracoGoogleMap.mapDatatype();
 
 if (typeof ItemEditing != 'undefined') {
-	ItemEditing.add_startEdit(function (item) {
-		var itemId = item._activeItem.itemId;
-		var container = jQuery('umbraco\\:iteminfo[itemid=' + itemId + ']');
-		if (jQuery.browser.msie) {
-			container = jQuery('*[itemid=' + itemId + ']');
-		}
-		if (jQuery("div.map", container).size() > 0) {
-			jQuery('input.value').focus(function () {
-				$(this).blur();
-			});
-			var mapId = jQuery('div.map', container).attr('id');
-			UmbracoGoogleMapMapDataType.preEdit(mapId, container);
-		}
-	});
+    ItemEditing.add_startEdit(function (item) {
+        var itemId = item._activeItem.itemId;
+        var container = jQuery('umbraco\\:iteminfo[itemid=' + itemId + ']');
+        if (jQuery.browser.msie) {
+            container = jQuery('*[itemid=' + itemId + ']');
+        }
+        if (jQuery("div.map", container).size() > 0) {
+            jQuery('input.value').focus(function () {
+                $(this).blur();
+            });
+            var mapId = jQuery('div.map', container).attr('id');
+            UmbracoGoogleMapMapDataType.preEdit(mapId, container);
+        }
+    });
 } else {
 
-	jQuery(document).ready(function () {
-		UmbracoGoogleMap.loadMapsApi('UmbracoGoogleMapMapDataType.guiMap');
+    jQuery(document).ready(function () {
+        UmbracoGoogleMap.loadMapsApi('UmbracoGoogleMapMapDataType.guiMap');
 
-		jQuery('input.value').focus(function () {
-			$(this).blur();
-		});
+        jQuery('input.value').focus(function () {
+            $(this).blur();
+        });
 
-		$('a').click(function () {
-			var id = $(this).attr('id');
-			if (id && id.indexOf('TabView') > -1) {
+        $('a').click(function () {
+            var id = $(this).attr('id');
+            if (id && id.indexOf('TabView') > -1) {
 
-				id = id.replace(/^(.*\_tab\d+).*$/, "$1");
-				id += 'layer';
+                id = id.replace(/^(.*\_tab\d+).*$/, "$1");
+                id += 'layer';
 
-				if (!UmbracoGoogleMapMapDataType._renderedTabs[id]) {
-					jQuery('#' + id).each(function () {
-						jQuery('div.map', this).each(function () {
-							var id = jQuery(this).attr('id');
-							if (UmbracoGoogleMapMapDataType._maps[id]) {
-								UmbracoGoogleMapMapDataType._maps[id].render();
-							}
-						});
-					});
+                if (!UmbracoGoogleMapMapDataType._renderedTabs[id]) {
+                    jQuery('#' + id).each(function () {
+                        jQuery('div.map', this).each(function () {
+                            var id = jQuery(this).attr('id');
+                            if (UmbracoGoogleMapMapDataType._maps[id]) {
+                                UmbracoGoogleMapMapDataType._maps[id].render();
+                            }
+                        });
+                    });
 
-					UmbracoGoogleMapMapDataType._renderedTabs[id] = true;
-				}
-			}
-		});
+                    UmbracoGoogleMapMapDataType._renderedTabs[id] = true;
+                }
+            }
+        });
 
-		$('.gmapContainer').find('.place').keydown(function (e) {
-			var keyCode = e.keyCode || e.which;
-			if (keyCode == 13) {
-				e.preventDefault();
-				$(this).parent().find('.button').click();
-				return false;
-			}
-		});
-	});
+        $('.gmapContainer').find('.place').keydown(function (e) {
+            var keyCode = e.keyCode || e.which;
+            if (keyCode == 13) {
+                e.preventDefault();
+                $(this).parent().find('.button').click();
+                return false;
+            }
+        });
+    });
 }

--- a/Our.Umbraco.GoogleMaps/DataTypes/SingleLocation/SingleLocationControl.cs
+++ b/Our.Umbraco.GoogleMaps/DataTypes/SingleLocation/SingleLocationControl.cs
@@ -105,6 +105,12 @@ namespace Our.Umbraco.GoogleMaps.DataTypes.SingleLocation
 		/// <value>A boolean which indicates whether one map point or multiple will be used.</value>
 		public string UseOnlyOneMapPoint { get; set; }
 
+        /// <summary>
+        /// Gets or sets the whether to reverse geocode any searches containing Lat/Long points.
+        /// </summary>
+        /// <value>True or false depending on whether reverse geocoding used used any searches containing Lat/Long points.</value>
+        public string ReverseGeocode { get; set; }
+
 		/// <summary>
 		/// Gets or sets the google map.
 		/// </summary>
@@ -128,6 +134,12 @@ namespace Our.Umbraco.GoogleMaps.DataTypes.SingleLocation
 		/// </summary>
 		/// <value>True or false depending on whether only one map point or multiple will be used.</value>
 		public HtmlInputHidden HiddenUseOnlyOnePoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the whether to reverse geocode any searches containing Lat/Long points.
+        /// </summary>
+        /// <value>True or false depending on whether reverse geocoding used used any searches containing Lat/Long points.</value>
+        public HtmlInputHidden HiddenReverseGeocode { get; set; }
 
 		/// <summary>
 		/// Gets or sets the location text box.
@@ -273,6 +285,14 @@ namespace Our.Umbraco.GoogleMaps.DataTypes.SingleLocation
 			};
 			this.HiddenUseOnlyOnePoint.Attributes.Add("class", "useOnlyOnePoint");
 			this.Controls.Add(this.HiddenUseOnlyOnePoint);
+
+            this.HiddenReverseGeocode = new HtmlInputHidden()
+            {
+                ID = string.Concat("reverseGeocode_", this.ClientID),
+                Value = this.UseOnlyOneMapPoint.ToLower()
+            };
+            this.HiddenUseOnlyOnePoint.Attributes.Add("class", "reverseGeocode");
+            this.Controls.Add(this.HiddenUseOnlyOnePoint);
 		}
 	}
 }

--- a/Our.Umbraco.GoogleMaps/DataTypes/SingleLocation/SingleLocationDataType.cs
+++ b/Our.Umbraco.GoogleMaps/DataTypes/SingleLocation/SingleLocationDataType.cs
@@ -99,6 +99,13 @@ namespace Our.Umbraco.GoogleMaps.DataTypes.SingleLocation
 		[DataEditorSetting("Single Map Point", description = "Automatically selects the first marker from the search.", defaultValue = "False", type = typeof(CheckBox))]
 		public string UseOnlyOneMapPoint { get; set; }
 
+        /// <summary>
+        /// Gets or sets whether to reverse geocode any searches containing Lat/Long points.
+		/// </summary>
+        /// <value>A boolean indicating whether or not to reverse geocode any searches containing Lat/Long points.</value>
+		[DataEditorSetting("Reverse Geocode", description = "Whether to reverse geocode any searches containing Lat/Long points.", defaultValue = "True", type = typeof(CheckBox))]
+		public string ReverseGeocode { get; set; }
+
 		/// <summary>
 		/// Handles the Init event of the m_Control control.
 		/// </summary>
@@ -113,6 +120,7 @@ namespace Our.Umbraco.GoogleMaps.DataTypes.SingleLocation
 			this.m_Control.MapWidth = this.MapWidth;
 			this.m_Control.SearchFilter = this.SearchFilter ?? string.Empty;
 			this.m_Control.UseOnlyOneMapPoint = this.UseOnlyOneMapPoint ?? bool.FalseString;
+		    this.m_Control.ReverseGeocode = this.ReverseGeocode ?? bool.TrueString;
 		}
 
 		/// <summary>

--- a/_build/package.xml
+++ b/_build/package.xml
@@ -34,6 +34,7 @@
 				<PreValue Id="4" Alias="MapWidth" Value="459" />
 				<PreValue Id="5" Alias="SearchFilter" Value="" />
 				<PreValue Id="6" Alias="UseOnlyOneMapPoint" Value="False" />
+        <PreValue Id="6" Alias="ReverseGeocode" Value="True" />
 			</PreValues>
 		</DataType>
 	</DataTypes>


### PR DESCRIPTION
This adds a new option to the data type which allows you to prevent reverse geocoding of lat/long searches which causes the given lat/long to be changed. This is especially useful if the client has given you an excel spreadsheet containing a list of lat/long values pointing to the middle of the Scottish countryside. :imp: 

Also fixed popup scrollbars appearing on infowindow.

Apologies for the formatting issues. I can't get it to play nice.
